### PR TITLE
fix #15

### DIFF
--- a/querystring_parser/parser.py
+++ b/querystring_parser/parser.py
@@ -112,8 +112,8 @@ def parse(query_string, unquote=True, encoding='utf-8'):
         try:
             if unquote:
                 (var, val) = element.split("=")
-                var = urllib.unquote_plus(var)
-                val = urllib.unquote_plus(val)
+                var = urllib.unquote_plus(str(var))
+                val = urllib.unquote_plus(str(val))
             else:
                 (var, val) = element.split("=")
         except ValueError:


### PR DESCRIPTION
When I send utf-8 data to server, the following error raised.

example query string: `first_name=%D8%B9%D9%84%DB%8C`

error: `'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)`