### PR TITLE
querystring_parser requires six library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(name='querystring_parser',
       packages=['querystring_parser'],
       install_requires=[
         "requests",
+        "six",
 	  ],
 )


### PR DESCRIPTION
I did `pip install querystring_parser` but it didn't worked on my project.

```
Internal Server Error: /{cut}/create
Traceback (most recent call last):
  File "/{cut}/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/{cut}/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/{cut}/views.py", line 25, in create_instance
    import querystring_parser.parser
  File "/{cut}/venv/lib/python2.7/site-packages/querystring_parser/parser.py", line 9, in <module>
    import six
ImportError: No module named six
```
